### PR TITLE
Date/Time and filename related improvements.

### DIFF
--- a/include/date.h
+++ b/include/date.h
@@ -10,7 +10,7 @@ enum class DateTimeFormat
     COUNT
 };
 
-char *GetDate(DateTimeFormat Format);
+std::string GetDate(DateTimeFormat Format);
 std::string RetTime();
 
 #endif // DATE_H

--- a/include/date.h
+++ b/include/date.h
@@ -7,6 +7,7 @@ enum class DateTimeFormat
 {
     FORMAT_YDM,
     FORMAT_YMD,
+    COUNT
 };
 
 char *GetDate(DateTimeFormat Format);

--- a/include/date.h
+++ b/include/date.h
@@ -1,12 +1,15 @@
 #ifndef DATE_H
 #define DATE_H
 
-#define FORMAT_YDM 0
-#define FORMAT_YMD 1
-
 #include <string>
 
-char *GetDate(int Format);
+enum class DateTimeFormat
+{
+    FORMAT_YDM,
+    FORMAT_YMD,
+};
+
+char *GetDate(DateTimeFormat Format);
 std::string RetTime();
 
 #endif // DATE_H

--- a/include/date.h
+++ b/include/date.h
@@ -10,6 +10,7 @@ enum class DateTimeFormat
     COUNT
 };
 
+std::string GetDateTimeFormatString(DateTimeFormat format);
 std::string GetDate(DateTimeFormat Format);
 std::string RetTime();
 

--- a/include/global.h
+++ b/include/global.h
@@ -50,6 +50,7 @@ extern FS_Archive sdArch;
 extern bool devMode, hbl, kill;
 //config
 extern bool centered, autoBack, useLang;
+extern bool Config_AutomaticallySetFilenameAsDateTime;
 
 //Allows app to be killed by hitting start
 void killApp(u32 up);

--- a/include/global.h
+++ b/include/global.h
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "date.h"
 #include "titledata.h"
 
 //this is for backup/restore modes
@@ -51,6 +52,7 @@ extern bool devMode, hbl, kill;
 //config
 extern bool centered, autoBack, useLang;
 extern bool Config_AutomaticallySetFilenameAsDateTime;
+extern DateTimeFormat Config_PreferredDateTimeFormat;
 
 //Allows app to be killed by hitting start
 void killApp(u32 up);

--- a/include/gstr.h
+++ b/include/gstr.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-std::string GetString(const char *hint);
+std::string GetString(const char *hint, bool allowAutoFilename);
 int getInt(const char *hint, int init, int maxValue);
 
 #endif // GSTR_H

--- a/source/backup.cpp
+++ b/source/backup.cpp
@@ -89,7 +89,7 @@ bool backupData(const titleData dat, FS_Archive arch, int mode, bool autoName)
     //if auto, just use date/time
     if(autoName)
     {
-        slot = tou16(GetDate(DateTimeFormat::FORMAT_YMD));
+        slot = tou16(GetDate(DateTimeFormat::FORMAT_YMD).c_str());
         if(autoBack)
             slot += tou16(" - AutoBack");
     }

--- a/source/backup.cpp
+++ b/source/backup.cpp
@@ -89,7 +89,7 @@ bool backupData(const titleData dat, FS_Archive arch, int mode, bool autoName)
     //if auto, just use date/time
     if(autoName)
     {
-        slot = tou16(GetDate(DateTimeFormat::FORMAT_YMD).c_str());
+        slot = tou16(GetDate(Config_PreferredDateTimeFormat).c_str());
         if(autoBack)
             slot += tou16(" - AutoBack");
     }

--- a/source/backup.cpp
+++ b/source/backup.cpp
@@ -89,7 +89,7 @@ bool backupData(const titleData dat, FS_Archive arch, int mode, bool autoName)
     //if auto, just use date/time
     if(autoName)
     {
-        slot = tou16(GetDate(FORMAT_YMD));
+        slot = tou16(GetDate(DateTimeFormat::FORMAT_YMD));
         if(autoBack)
             slot += tou16(" - AutoBack");
     }

--- a/source/date.cpp
+++ b/source/date.cpp
@@ -5,7 +5,7 @@
 #include "date.h"
 
 //This returns the date as a c string
-char *GetDate(int Format)
+char *GetDate(DateTimeFormat Format)
 {
     char *Ret = new char[24];
 
@@ -15,12 +15,12 @@ char *GetDate(int Format)
 
     switch(Format)
     {
-        case FORMAT_YDM:
+        case DateTimeFormat::FORMAT_YDM:
             {
                 sprintf(Ret, "%04d-%02d-%02d_%02d-%02d-%02d", Time->tm_year + 1900, Time->tm_mday, Time->tm_mon + 1, Time->tm_hour, Time->tm_min, Time->tm_sec);
                 break;
             }
-        case FORMAT_YMD:
+        case DateTimeFormat::FORMAT_YMD:
             {
                 sprintf(Ret, "%04d-%02d-%02d_%02d-%02d-%02d", Time->tm_year + 1900, Time->tm_mon + 1, Time->tm_mday, Time->tm_hour, Time->tm_min, Time->tm_sec);
                 break;

--- a/source/date.cpp
+++ b/source/date.cpp
@@ -4,6 +4,16 @@
 
 #include "date.h"
 
+std::string GetDateTimeFormatString(DateTimeFormat format)
+{
+    switch (format)
+    {
+        case DateTimeFormat::FORMAT_YDM: return "YYYY-DD-MM";
+        case DateTimeFormat::FORMAT_YMD: return "YYYY-MM-DD";
+        default: return "UNKNOWN";
+    }
+}
+
 //This returns the date as a string
 std::string GetDate(DateTimeFormat Format)
 {

--- a/source/date.cpp
+++ b/source/date.cpp
@@ -4,10 +4,10 @@
 
 #include "date.h"
 
-//This returns the date as a c string
-char *GetDate(DateTimeFormat Format)
+//This returns the date as a string
+std::string GetDate(DateTimeFormat Format)
 {
-    char *Ret = new char[24];
+    char Ret[24];
 
     time_t Raw;
     time(&Raw);
@@ -28,7 +28,7 @@ char *GetDate(DateTimeFormat Format)
             }
     }
 
-    return Ret;
+    return std::string(Ret);
 }
 
 //this returns the time for the top bar

--- a/source/date.cpp
+++ b/source/date.cpp
@@ -21,6 +21,7 @@ char *GetDate(DateTimeFormat Format)
                 break;
             }
         case DateTimeFormat::FORMAT_YMD:
+        default:
             {
                 sprintf(Ret, "%04d-%02d-%02d_%02d-%02d-%02d", Time->tm_year + 1900, Time->tm_mon + 1, Time->tm_mday, Time->tm_hour, Time->tm_min, Time->tm_sec);
                 break;

--- a/source/extra.cpp
+++ b/source/extra.cpp
@@ -105,6 +105,7 @@ enum extraOpts
     centeredText,
     autoBackAtRest,
     useSysLang,
+    automaticallySetFilenameAsDateTime,
     bgColor,
     slColor,
     unslColor,
@@ -126,6 +127,7 @@ void saveCfg()
     fputc(centered, config);
     fputc(autoBack, config);
     fputc(useLang, config);
+    fputc(Config_AutomaticallySetFilenameAsDateTime, config);
 
     fclose(config);
 }
@@ -146,6 +148,7 @@ void prepExtras()
     extra.addItem(std::string("Centered text: " + onOff(centered)).c_str());
     extra.addItem(std::string("Auto Backup: " + onOff(autoBack)).c_str());
     extra.addItem(std::string("Use System Language: " + onOff(useLang)).c_str());
+    extra.addItem(std::string("Auto Filename: " + onOff(Config_AutomaticallySetFilenameAsDateTime)).c_str());
     extra.addItem("Set Background Color");
     extra.addItem("Set Selected Item Color");
     extra.addItem("Set Unselected Item Color");
@@ -160,6 +163,7 @@ static const std::string helpDescs[] =
     "Sets whether title select, nand title select, and folder select menus are centered. (Requires reboot to take effect.)",
     "Automatically creates a backup when save data is imported. Just in case!",
     "Uses system language when getting titles. Defaults to English if title is empty.",
+    "Automatically sets the filename to the current date and time instead of asking when exporting a save to a new folder.",
     "Sets the background color. Asks for RGB info in that order",
     "Sets the color of selected options in menus. Asks for RGB info in that order",
     "Sets the color of unselected menu options. Asks for RGB info in that order",
@@ -194,6 +198,11 @@ void extrasMenu()
             case extraOpts::useSysLang:
                 switchBool(&useLang);
                 extra.updateItem(extraOpts::useSysLang, std::string("Use System Language: " + onOff(useLang)).c_str());
+                saveCfg();
+                break;
+            case extraOpts::automaticallySetFilenameAsDateTime:
+                switchBool(&Config_AutomaticallySetFilenameAsDateTime);
+                extra.updateItem(extraOpts::automaticallySetFilenameAsDateTime, std::string("Auto Filename: " + onOff(Config_AutomaticallySetFilenameAsDateTime)).c_str());
                 saveCfg();
                 break;
             case extraOpts::bgColor:

--- a/source/extra.cpp
+++ b/source/extra.cpp
@@ -106,6 +106,7 @@ enum extraOpts
     autoBackAtRest,
     useSysLang,
     automaticallySetFilenameAsDateTime,
+    preferredDateTimeFormat,
     bgColor,
     slColor,
     unslColor,
@@ -128,6 +129,7 @@ void saveCfg()
     fputc(autoBack, config);
     fputc(useLang, config);
     fputc(Config_AutomaticallySetFilenameAsDateTime, config);
+    fputc(static_cast<int>(Config_PreferredDateTimeFormat) & 0xFF, config);
 
     fclose(config);
 }
@@ -140,6 +142,13 @@ void switchBool(bool *sw)
         *sw = true;
 }
 
+void cycleInt(int* sw, int max)
+{
+    ++(*sw);
+    if (*sw >= max)
+        *sw = 0;
+}
+
 static menu extra(136, 80, false, true);
 
 void prepExtras()
@@ -149,6 +158,7 @@ void prepExtras()
     extra.addItem(std::string("Auto Backup: " + onOff(autoBack)).c_str());
     extra.addItem(std::string("Use System Language: " + onOff(useLang)).c_str());
     extra.addItem(std::string("Auto Filename: " + onOff(Config_AutomaticallySetFilenameAsDateTime)).c_str());
+    extra.addItem(std::string("Preferred Date Format: " + GetDateTimeFormatString(Config_PreferredDateTimeFormat)).c_str());
     extra.addItem("Set Background Color");
     extra.addItem("Set Selected Item Color");
     extra.addItem("Set Unselected Item Color");
@@ -164,6 +174,7 @@ static const std::string helpDescs[] =
     "Automatically creates a backup when save data is imported. Just in case!",
     "Uses system language when getting titles. Defaults to English if title is empty.",
     "Automatically sets the filename to the current date and time instead of asking when exporting a save to a new folder.",
+    "Set the preferred date and time format.",
     "Sets the background color. Asks for RGB info in that order",
     "Sets the color of selected options in menus. Asks for RGB info in that order",
     "Sets the color of unselected menu options. Asks for RGB info in that order",
@@ -205,6 +216,15 @@ void extrasMenu()
                 extra.updateItem(extraOpts::automaticallySetFilenameAsDateTime, std::string("Auto Filename: " + onOff(Config_AutomaticallySetFilenameAsDateTime)).c_str());
                 saveCfg();
                 break;
+            case extraOpts::preferredDateTimeFormat:
+            {
+                int tmp = static_cast<int>(Config_PreferredDateTimeFormat);
+                cycleInt(&tmp, static_cast<int>(DateTimeFormat::COUNT));
+                Config_PreferredDateTimeFormat = static_cast<DateTimeFormat>(tmp);
+                extra.updateItem(extraOpts::preferredDateTimeFormat, std::string("Preferred Date Format: " + GetDateTimeFormatString(Config_PreferredDateTimeFormat)).c_str());
+                saveCfg();
+                break;
+            }
             case extraOpts::bgColor:
                 setBGColor();
                 break;

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -33,6 +33,7 @@ bool hbl = false, devMode = false, kill = false;
 //config
 bool centered = true, autoBack = false, useLang = false;
 bool Config_AutomaticallySetFilenameAsDateTime = false;
+DateTimeFormat Config_PreferredDateTimeFormat = DateTimeFormat::FORMAT_YMD;
 
 //default colors
 u8 clearColor[3] = {0, 0, 0};

--- a/source/global.cpp
+++ b/source/global.cpp
@@ -32,6 +32,7 @@ bool hbl = false, devMode = false, kill = false;
 
 //config
 bool centered = true, autoBack = false, useLang = false;
+bool Config_AutomaticallySetFilenameAsDateTime = false;
 
 //default colors
 u8 clearColor[3] = {0, 0, 0};

--- a/source/gstr.cpp
+++ b/source/gstr.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <string>
 
 #include <3ds.h>
@@ -26,11 +27,12 @@ std::string GetString(const char *hint)
     swkbdInit(&keyState, SWKBD_TYPE_NORMAL, 2, 64);
     swkbdSetHintText(&keyState, hint);
     swkbdSetFeatures(&keyState, SWKBD_PREDICTIVE_INPUT);
-    SwkbdDictWord dates[2];
-    swkbdSetDictWord(&dates[0], "2016", GetDate(DateTimeFormat::FORMAT_YDM));
-    swkbdSetDictWord(&dates[1], "2016", GetDate(DateTimeFormat::FORMAT_YMD));
+    std::array<SwkbdDictWord, static_cast<size_t>(DateTimeFormat::COUNT)> dates;
+    for (size_t i = 0; i < dates.size(); ++i) {
+        swkbdSetDictWord(&dates[i], "2016", GetDate(static_cast<DateTimeFormat>(i)));
+    }
     swkbdSetInitialText(&keyState, GetDate(DateTimeFormat::FORMAT_YMD));
-    swkbdSetDictionary(&keyState, dates, 2);
+    swkbdSetDictionary(&keyState, &dates[0], static_cast<int>(dates.size()));
 
     swkbdInputText(&keyState, input, 64);
 

--- a/source/gstr.cpp
+++ b/source/gstr.cpp
@@ -16,9 +16,9 @@ std::string GetString(const char *hint)
 
     u32 held = hidKeysHeld();
     if(held & KEY_L)
-        return GetDate(FORMAT_YDM);
+        return GetDate(DateTimeFormat::FORMAT_YDM);
     else if(held & KEY_R)
-        return  GetDate(FORMAT_YMD);
+        return GetDate(DateTimeFormat::FORMAT_YMD);
 
     SwkbdState keyState;
     char input[64];
@@ -27,9 +27,9 @@ std::string GetString(const char *hint)
     swkbdSetHintText(&keyState, hint);
     swkbdSetFeatures(&keyState, SWKBD_PREDICTIVE_INPUT);
     SwkbdDictWord dates[2];
-    swkbdSetDictWord(&dates[0], "2016", GetDate(FORMAT_YDM));
-    swkbdSetDictWord(&dates[1], "2016", GetDate(FORMAT_YMD));
-    swkbdSetInitialText(&keyState, GetDate(FORMAT_YMD));
+    swkbdSetDictWord(&dates[0], "2016", GetDate(DateTimeFormat::FORMAT_YDM));
+    swkbdSetDictWord(&dates[1], "2016", GetDate(DateTimeFormat::FORMAT_YMD));
+    swkbdSetInitialText(&keyState, GetDate(DateTimeFormat::FORMAT_YMD));
     swkbdSetDictionary(&keyState, dates, 2);
 
     swkbdInputText(&keyState, input, 64);

--- a/source/gstr.cpp
+++ b/source/gstr.cpp
@@ -14,7 +14,7 @@
 std::string GetString(const char *hint, bool allowAutoFilename)
 {
     if (allowAutoFilename && Config_AutomaticallySetFilenameAsDateTime)
-        return GetDate(DateTimeFormat::FORMAT_YMD);
+        return GetDate(Config_PreferredDateTimeFormat);
 
     hidScanInput();
 
@@ -34,7 +34,7 @@ std::string GetString(const char *hint, bool allowAutoFilename)
     for (size_t i = 0; i < dates.size(); ++i) {
         swkbdSetDictWord(&dates[i], "2016", GetDate(static_cast<DateTimeFormat>(i)).c_str());
     }
-    std::string initialText = GetDate(DateTimeFormat::FORMAT_YMD);
+    std::string initialText = GetDate(Config_PreferredDateTimeFormat);
     swkbdSetInitialText(&keyState, initialText.c_str());
     swkbdSetDictionary(&keyState, &dates[0], static_cast<int>(dates.size()));
 

--- a/source/gstr.cpp
+++ b/source/gstr.cpp
@@ -11,8 +11,11 @@
 #include "date.h"
 #include "ui.h"
 
-std::string GetString(const char *hint)
+std::string GetString(const char *hint, bool allowAutoFilename)
 {
+    if (allowAutoFilename && Config_AutomaticallySetFilenameAsDateTime)
+        return GetDate(DateTimeFormat::FORMAT_YMD);
+
     hidScanInput();
 
     u32 held = hidKeysHeld();

--- a/source/gstr.cpp
+++ b/source/gstr.cpp
@@ -29,9 +29,10 @@ std::string GetString(const char *hint)
     swkbdSetFeatures(&keyState, SWKBD_PREDICTIVE_INPUT);
     std::array<SwkbdDictWord, static_cast<size_t>(DateTimeFormat::COUNT)> dates;
     for (size_t i = 0; i < dates.size(); ++i) {
-        swkbdSetDictWord(&dates[i], "2016", GetDate(static_cast<DateTimeFormat>(i)));
+        swkbdSetDictWord(&dates[i], "2016", GetDate(static_cast<DateTimeFormat>(i)).c_str());
     }
-    swkbdSetInitialText(&keyState, GetDate(DateTimeFormat::FORMAT_YMD));
+    std::string initialText = GetDate(DateTimeFormat::FORMAT_YMD);
+    swkbdSetInitialText(&keyState, initialText.c_str());
     swkbdSetDictionary(&keyState, &dates[0], static_cast<int>(dates.size()));
 
     swkbdInputText(&keyState, input, 64);

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -82,7 +82,7 @@ void menu::addItem(const std::u16string a)
 void menu::updateItem(int i, const char *a)
 {
     char32_t tmp[128];
-    memset(tmp, 0, 128);
+    memset(tmp, 0, sizeof(char32_t) * 128);
 
     utf8_to_utf32((uint32_t *)tmp, (uint8_t *)a, 128);
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -49,7 +49,7 @@ menu::~menu()
 
 void menu::addItem(const char *a)
 {
-    char32_t *tmp = new char32_t[128];
+    char32_t tmp[128];
     memset(tmp, 0, sizeof(char32_t) * 128);
     utf8_to_utf32((uint32_t *)tmp, (uint8_t *)a, 128);
 
@@ -59,13 +59,11 @@ void menu::addItem(const char *a)
     menuItem add(t, center, x);
 
     opts.push_back(add);
-
-    delete[] tmp;
 }
 
 void menu::addItem(const std::u16string a)
 {
-    char32_t *tmp = new char32_t[128];
+    char32_t tmp[128];
     memset(tmp, 0, sizeof(char32_t) * 128);
     utf16_to_utf32((uint32_t *)tmp, (uint16_t *)a.data(), 128);
 
@@ -75,8 +73,6 @@ void menu::addItem(const std::u16string a)
     menuItem add(t, center, x);
 
     opts.push_back(add);
-
-    delete[] tmp;
 }
 
 void menu::updateItem(int i, const char *a)

--- a/source/slot.cpp
+++ b/source/slot.cpp
@@ -59,7 +59,7 @@ std::u16string getFolder(const titleData dat, int mode, bool newFolder)
 
         if( (down & KEY_A) && ((u32)folderMenu.getSelected() + 1 > dir.count()))
         {
-            ret = tou16(GetString("Enter a name for the new folder.").c_str());
+            ret = tou16(GetString("Enter a name for the new folder.", true).c_str());
             break;
         }
         else if(down & KEY_A)
@@ -69,7 +69,7 @@ std::u16string getFolder(const titleData dat, int mode, bool newFolder)
         }
         else if(down & KEY_X)
         {
-            std::u16string newName = tou16(GetString("Enter a new name.").c_str());
+            std::u16string newName = tou16(GetString("Enter a new name.", false).c_str());
             if(!newName.empty() && (u32)folderMenu.getSelected() < dir.count())
             {
                 std::u16string oldPath = path + dir.retItem(folderMenu.getSelected());

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -57,6 +57,10 @@ void loadCfg()
     if (tmp == EOF) { fclose(config); return; }
     useLang = static_cast<bool>(tmp);
 
+    tmp = fgetc(config);
+    if (tmp == EOF) { fclose(config); return; }
+    Config_AutomaticallySetFilenameAsDateTime = static_cast<bool>(tmp);
+
     fclose(config);
 }
 

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -61,6 +61,10 @@ void loadCfg()
     if (tmp == EOF) { fclose(config); return; }
     Config_AutomaticallySetFilenameAsDateTime = static_cast<bool>(tmp);
 
+    tmp = fgetc(config);
+    if (tmp == EOF) { fclose(config); return; }
+    Config_PreferredDateTimeFormat = tmp >= static_cast<int>(DateTimeFormat::COUNT) ? DateTimeFormat::FORMAT_YMD : static_cast<DateTimeFormat>(tmp);
+
     fclose(config);
 }
 

--- a/source/sys.cpp
+++ b/source/sys.cpp
@@ -42,10 +42,20 @@ void loadCol()
 void loadCfg()
 {
     FILE *config = fopen("config", "rb");
+    if (!config) { return; }
+    int tmp;
 
-    centered = fgetc(config);
-    autoBack = fgetc(config);
-    useLang = fgetc(config);
+    tmp = fgetc(config);
+    if (tmp == EOF) { fclose(config); return; }
+    centered = static_cast<bool>(tmp);
+
+    tmp = fgetc(config);
+    if (tmp == EOF) { fclose(config); return; }
+    autoBack = static_cast<bool>(tmp);
+
+    tmp = fgetc(config);
+    if (tmp == EOF) { fclose(config); return; }
+    useLang = static_cast<bool>(tmp);
 
     fclose(config);
 }


### PR DESCRIPTION
I'm a guy who gets annoyed when a game forces me to use a touchscreen for a thing that could really just be entirely button-controlled, so I added a few features that allow me to skip the keyboard filename popup unless really necessary.

These are:

- An option in the Config menu that automatically uses the current date/time for the filename when exporting a save to a new slot.
- An option in the Config menu to allow me to choose my preferred date/time format for those autogenerated names. This also affects the automatically filled in default filename on the keyboard if you do not use the auto-filename option.

Yes, I have noticed that there were also quick-selects on L and R that would have just allowed me to skip the keyboard, but that feels clunky, especially since that feature doesn't seem to be documented. I figured this way is cleaner.

I've also cleaned up some code in the vicinity of the things I had to modify. `GetDate()` now no longer leaks 24 bytes per call, `menu::updateItem()` now properly zero-initializes its result array (which matters if the input is 32 characters or longer), and less unnecessary heap allocations in `menu` in general.